### PR TITLE
Manually lookup module integrity if bom tool doesn't find a hash

### DIFF
--- a/init_test.go
+++ b/init_test.go
@@ -12,5 +12,6 @@ func TestUnitNodeModuleBOM(t *testing.T) {
 	suite("Build", testBuild)
 	suite("Detect", testDetect)
 	suite("ModuleBOM", testModuleBOM)
+	suite("PackageLock", testPackageLock)
 	suite.Run(t)
 }

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -118,6 +118,7 @@ func TestIntegration(t *testing.T) {
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("NPM", testNPM)
+	suite("Node16", testNode16)
 	suite("Offline", testOffline)
 	suite("Vendored", testVendored)
 	suite("Yarn", testYarn)

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -118,7 +118,7 @@ func TestIntegration(t *testing.T) {
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("NPM", testNPM)
-	suite("Node16", testNode16)
+	suite("PackageLockHashes", testPackageLockHashes)
 	suite("Offline", testOffline)
 	suite("Vendored", testVendored)
 	suite("Yarn", testYarn)

--- a/integration/node_16_test.go
+++ b/integration/node_16_test.go
@@ -1,0 +1,84 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testNode16(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+	})
+
+	context("when the buildpack is run with pack build", func() {
+		var (
+			image     occam.Image
+			container occam.Container
+			name      string
+			source    string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		context("building an NPM app with Node Engine v16", func() {
+			it.After(func() {
+				Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+			})
+
+			it("builds, logs and runs correctly", func() {
+				var err error
+
+				source, err = occam.Source(filepath.Join("testdata", "node_16_app"))
+				Expect(err).ToNot(HaveOccurred())
+
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithPullPolicy("never").
+					WithBuildpacks(
+						nodeEngineBuildpack,
+						npmInstallBuildpack,
+						nodeModuleBOMBuildpack,
+						npmStartBuildpack,
+					).
+					Execute(name, source)
+				Expect(err).ToNot(HaveOccurred(), logs.String)
+
+				container, err = docker.Container.Run.
+					WithPublish("8080").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(BeAvailable())
+				Eventually(container).Should(Serve(ContainSubstring("hello world")).OnPort(8080))
+				Expect(image.Labels["io.buildpacks.build.metadata"]).To(ContainSubstring(`"name":"leftpad","metadata":{"checksum":`))
+			})
+		})
+	})
+}

--- a/integration/package_lock_hashes_test.go
+++ b/integration/package_lock_hashes_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/paketo-buildpacks/occam/matchers"
 )
 
-func testNode16(t *testing.T, context spec.G, it spec.S) {
+func testPackageLockHashes(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect     = NewWithT(t).Expect
 		Eventually = NewWithT(t).Eventually
@@ -47,7 +47,7 @@ func testNode16(t *testing.T, context spec.G, it spec.S) {
 			Expect(os.RemoveAll(source)).To(Succeed())
 		})
 
-		context("building an NPM app with Node Engine v16", func() {
+		context("building an NPM app that uses a NPM version with package-lock.json lockfile version 2", func() {
 			it.After(func() {
 				Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
 			})
@@ -55,7 +55,7 @@ func testNode16(t *testing.T, context spec.G, it spec.S) {
 			it("builds, logs and runs correctly", func() {
 				var err error
 
-				source, err = occam.Source(filepath.Join("testdata", "node_16_app"))
+				source, err = occam.Source(filepath.Join("testdata", "npm_app"))
 				Expect(err).ToNot(HaveOccurred())
 
 				var logs fmt.Stringer
@@ -67,6 +67,7 @@ func testNode16(t *testing.T, context spec.G, it spec.S) {
 						nodeModuleBOMBuildpack,
 						npmStartBuildpack,
 					).
+					WithEnv(map[string]string{"BP_NODE_VERSION": "~16"}).
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 

--- a/integration/testdata/node_16_app/README.md
+++ b/integration/testdata/node_16_app/README.md
@@ -1,0 +1,1 @@
+This file here to suppress "npm WARN package.json node_web_app@0.0.0 No README data"

--- a/integration/testdata/node_16_app/package.json
+++ b/integration/testdata/node_16_app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "npm_app",
+  "version": "0.0.0",
+  "description": "some NPM app",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "",
+  "dependencies": {
+    "leftpad": "~0.0.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": ""
+  },
+  "engines": {
+    "node": "~16"
+  }
+}

--- a/integration/testdata/node_16_app/server.js
+++ b/integration/testdata/node_16_app/server.js
@@ -1,0 +1,17 @@
+const http = require('http');
+const leftpad = require('leftpad');
+const port = process.env.PORT || 8080;
+
+const requestHandler = (request, response) => {
+    response.end("hello world")
+}
+
+const server = http.createServer(requestHandler)
+
+server.listen(port, (err) => {
+    if (err) {
+        return console.log('something bad happened', err)
+    }
+
+    console.log(`server is listening on ${port}`)
+})

--- a/module_bom.go
+++ b/module_bom.go
@@ -39,7 +39,6 @@ type packageLock struct {
 }
 
 func (m ModuleBOM) Generate(workingDir string) ([]packit.BOMEntry, error) {
-
 	buffer := bytes.NewBuffer(nil)
 	args := []string{"-o", "bom.json"}
 	m.logger.Subprocess("Running 'cyclonedx-bom %s'", strings.Join(args, " "))

--- a/module_bom.go
+++ b/module_bom.go
@@ -112,9 +112,15 @@ func (m ModuleBOM) Generate(workingDir string) ([]packit.BOMEntry, error) {
 			// just skip trying to get checksums
 			if err == nil {
 				alg, hash := retrieveIntegrityFromLockfile(packageLock, entry.Name)
-				packitEntry.Metadata["checksum"] = map[string]string{
-					"algorithm": alg,
-					"hash":      hash,
+
+				algorithm, err := packit.GetBOMChecksumAlgorithm(alg)
+				if err != nil {
+					return nil, err
+				}
+
+				packitEntry.Metadata.Checksum = packit.BOMChecksum{
+					Algorithm: algorithm,
+					Hash:      hash,
 				}
 			}
 		}

--- a/module_bom.go
+++ b/module_bom.go
@@ -30,7 +30,7 @@ func NewModuleBOM(executable Executable, logger scribe.Emitter) ModuleBOM {
 	}
 }
 
-type packageLockStruct struct {
+type packageLock struct {
 	Name            string                 `json:"name"`
 	LockfileVersion int                    `json:"lockfileVersion"`
 	Dependencies    map[string]interface{} `json:"dependencies"`
@@ -81,7 +81,7 @@ func (m ModuleBOM) Generate(workingDir string) ([]packit.BOMEntry, error) {
 		return nil, fmt.Errorf("failed to decode bom.json: %w", err)
 	}
 
-	var packageLock packageLockStruct
+	var packageLock packageLock
 	var entries []packit.BOMEntry
 	for _, entry := range bom.Components {
 		packitEntry := packit.BOMEntry{
@@ -135,17 +135,17 @@ func (m ModuleBOM) Generate(workingDir string) ([]packit.BOMEntry, error) {
 	return entries, nil
 }
 
-func getLockFile(workingDir string) (packageLockStruct, error) {
+func getLockFile(workingDir string) (packageLock, error) {
 	file, err := os.Open(filepath.Join(workingDir, "package-lock.json"))
 	if err != nil {
-		return packageLockStruct{}, fmt.Errorf("failed to open package-lock.json: %w", err)
+		return packageLock{}, fmt.Errorf("failed to open package-lock.json: %w", err)
 	}
 	defer file.Close()
 
-	var lockFile packageLockStruct
+	var lockFile packageLock
 	err = json.NewDecoder(file).Decode(&lockFile)
 	if err != nil {
-		return packageLockStruct{}, fmt.Errorf("failed to decode package-lock: %w", err)
+		return packageLock{}, fmt.Errorf("failed to decode package-lock: %w", err)
 	}
 	return lockFile, nil
 }
@@ -153,7 +153,7 @@ func getLockFile(workingDir string) (packageLockStruct, error) {
 // retrieveIntegrityFromLockfile is a function that will read the
 // package-lock.json if there is one, and retrieve the integrity (hash) for a
 // specific dependency. It returns the hash algorithm and hash itself.
-func retrieveIntegrityFromLockfile(packageLock packageLockStruct, pkg string) (string, string) {
+func retrieveIntegrityFromLockfile(packageLock packageLock, pkg string) (string, string) {
 	for name, dependency := range packageLock.Dependencies {
 		if name == pkg {
 			dependencyMap := dependency.(map[string]interface{})

--- a/module_bom_test.go
+++ b/module_bom_test.go
@@ -84,6 +84,12 @@ func testModuleBOM(t *testing.T, context spec.G, it spec.S) {
       "name": "rightpad",
       "version": "1.0.0",
       "description": "right pad numbers",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "123456789"
+        }
+      ],
       "licenses": [
         {
           "license": {
@@ -143,6 +149,10 @@ func testModuleBOM(t *testing.T, context spec.G, it spec.S) {
 						PURL:     "pkg:npm/rightpad@1.0.0",
 						Licenses: []string{"Apache"},
 						Version:  "1.0.0",
+						Checksum: packit.BOMChecksum{
+							Algorithm: packit.SHA256,
+							Hash:      "123456789",
+						},
 					},
 				},
 			}))

--- a/module_bom_test.go
+++ b/module_bom_test.go
@@ -38,70 +38,68 @@ func testModuleBOM(t *testing.T, context spec.G, it spec.S) {
 
 		executable = &fakes.Executable{}
 		executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
-			Expect(os.WriteFile(filepath.Join(workingDir, "bom.json"), []byte(
-				`
-{
-  "bomFormat": "CycloneDX",
-  "specVersion": "1.3",
-  "serialNumber": "urn:uuid:a717bde3-8a77-4ec6-a530-5d0d9007ecbe",
-  "version": 1,
-  "metadata": {
-    "timestamp": "2021-08-16T19:35:52.107Z",
-    "tools": [
-      {
-        "vendor": "CycloneDX",
-        "name": "Node.js module",
-        "version": "3.0.3"
-      }
-    ],
-    "component": {
-      "type": "library"
-    }
-  },
-  "components": [
-    {
-      "type": "library",
-      "name": "leftpad",
-      "version": "0.0.1",
-      "description": "left pad numbers",
-      "hashes": [
-        {
-          "alg": "SHA-1",
-          "content": "86b1a4de4face180ac545a83f1503523d8fed115"
-        }
-      ],
-      "licenses": [
-        {
-          "license": {
-            "id": "BSD-3-Clause"
-          }
-        }
-      ],
-      "purl": "pkg:npm/leftpad@0.0.1"
-		},
-    {
-      "type": "library",
-      "name": "rightpad",
-      "version": "1.0.0",
-      "description": "right pad numbers",
-      "hashes": [
-        {
-          "alg": "SHA-256",
-          "content": "123456789"
-        }
-      ],
-      "licenses": [
-        {
-          "license": {
-            "id": "Apache"
-          }
-        }
-      ],
-			"purl": "pkg:npm/rightpad@1.0.0"
-    }
-  ]
-}
-`), 0600)).To(Succeed())
+			Expect(os.WriteFile(filepath.Join(workingDir, "bom.json"), []byte(`{
+				"bomFormat": "CycloneDX",
+				"specVersion": "1.3",
+				"serialNumber": "urn:uuid:a717bde3-8a77-4ec6-a530-5d0d9007ecbe",
+				"version": 1,
+				"metadata": {
+					"timestamp": "2021-08-16T19:35:52.107Z",
+					"tools": [
+						{
+							"vendor": "CycloneDX",
+							"name": "Node.js module",
+							"version": "3.0.3"
+						}
+					],
+					"component": {
+						"type": "library"
+					}
+				},
+				"components": [
+					{
+						"type": "library",
+						"name": "leftpad",
+						"version": "0.0.1",
+						"description": "left pad numbers",
+						"hashes": [
+							{
+								"alg": "SHA-1",
+								"content": "86b1a4de4face180ac545a83f1503523d8fed115"
+							}
+						],
+						"licenses": [
+							{
+								"license": {
+									"id": "BSD-3-Clause"
+								}
+							}
+						],
+						"purl": "pkg:npm/leftpad@0.0.1"
+					},
+					{
+						"type": "library",
+						"name": "rightpad",
+						"version": "1.0.0",
+						"description": "right pad numbers",
+						"hashes": [
+							{
+								"alg": "SHA-256",
+								"content": "123456789"
+							}
+						],
+						"licenses": [
+							{
+								"license": {
+									"id": "Apache"
+								}
+							}
+						],
+						"purl": "pkg:npm/rightpad@1.0.0"
+					}
+				]
+			}
+			`), 0600)).To(Succeed())
 			return nil
 		}
 
@@ -163,43 +161,39 @@ func testModuleBOM(t *testing.T, context spec.G, it spec.S) {
 		context("the bom.json does not contain hashes for node_modules", func() {
 			it.Before(func() {
 				executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
-					Expect(os.WriteFile(filepath.Join(workingDir, "bom.json"), []byte(
-						`
-{
-  "components": [
-    {
-      "type": "library",
-      "name": "leftpad",
-      "version": "0.0.1",
-      "description": "left pad numbers",
-      "licenses": [
-        {
-          "license": {
-            "id": "BSD-3-Clause"
-          }
-        }
-      ],
-      "purl": "pkg:npm/leftpad@0.0.1"
-		}
-  ]
-}
-`), 0600)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(workingDir, "bom.json"), []byte(`{
+						"components": [
+							{
+								"type": "library",
+								"name": "leftpad",
+								"version": "0.0.1",
+								"description": "left pad numbers",
+								"licenses": [
+									{
+										"license": {
+											"id": "BSD-3-Clause"
+										}
+									}
+								],
+								"purl": "pkg:npm/leftpad@0.0.1"
+							}
+						]
+					}`), 0600)).To(Succeed())
 					return nil
 				}
 
 				Expect(os.WriteFile(filepath.Join(workingDir, "package-lock.json"), []byte(`
-{
-  "name": "simple_app",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "leftpad": {
-      "version": "0.0.1",
-			"integrity": "sha512-SSB3aXNoIEkgd2FzIGEgYmFsbGVy"
-    }
-  }
-}
-`), 0600)).To(Succeed())
+					{
+						"name": "simple_app",
+						"lockfileVersion": 1,
+						"requires": true,
+						"dependencies": {
+							"leftpad": {
+								"version": "0.0.1",
+								"integrity": "sha512-SSB3aXNoIEkgd2FzIGEgYmFsbGVy"
+							}
+						}
+					}`), 0600)).To(Succeed())
 
 			})
 			it.After(func() {
@@ -236,43 +230,38 @@ func testModuleBOM(t *testing.T, context spec.G, it spec.S) {
 		context("the bom.json has no hashes and cannot open package-lock.json", func() {
 			it.Before(func() {
 				executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
-					Expect(os.WriteFile(filepath.Join(workingDir, "bom.json"), []byte(
-						`
-{
-  "components": [
-    {
-      "type": "library",
-      "name": "leftpad",
-      "version": "0.0.1",
-      "description": "left pad numbers",
-      "licenses": [
-        {
-          "license": {
-            "id": "BSD-3-Clause"
-          }
-        }
-      ],
-      "purl": "pkg:npm/leftpad@0.0.1"
-		}
-  ]
-}
-`), 0600)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(workingDir, "bom.json"), []byte(`{
+						"components": [
+							{
+								"type": "library",
+								"name": "leftpad",
+								"version": "0.0.1",
+								"description": "left pad numbers",
+								"licenses": [
+									{
+										"license": {
+											"id": "BSD-3-Clause"
+										}
+									}
+								],
+								"purl": "pkg:npm/leftpad@0.0.1"
+							}
+						]
+					}`), 0600)).To(Succeed())
 					return nil
 				}
 
-				Expect(os.WriteFile(filepath.Join(workingDir, "package-lock.json"), []byte(`
-{
-  "name": "simple_app",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "leftpad": {
-      "version": "0.0.1",
-			"integrity": "sha521-hashFromPackageLockJson"
-    }
-  }
-}
-`), 0000)).To(Succeed())
+				Expect(os.WriteFile(filepath.Join(workingDir, "package-lock.json"), []byte(`{
+						"name": "simple_app",
+						"lockfileVersion": 1,
+						"requires": true,
+						"dependencies": {
+							"leftpad": {
+								"version": "0.0.1",
+								"integrity": "sha521-hashFromPackageLockJson"
+							}
+						}
+					}`), 0000)).To(Succeed())
 
 			})
 			it.After(func() {
@@ -297,27 +286,24 @@ func testModuleBOM(t *testing.T, context spec.G, it spec.S) {
 		context("the bom.json has no hashes and cannot unmarshal package-lock.json", func() {
 			it.Before(func() {
 				executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
-					Expect(os.WriteFile(filepath.Join(workingDir, "bom.json"), []byte(
-						`
-{
-  "components": [
-    {
-      "type": "library",
-      "name": "leftpad",
-      "version": "0.0.1",
-      "description": "left pad numbers",
-      "licenses": [
-        {
-          "license": {
-            "id": "BSD-3-Clause"
-          }
-        }
-      ],
-      "purl": "pkg:npm/leftpad@0.0.1"
-		}
-  ]
-}
-`), 0600)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(workingDir, "bom.json"), []byte(`{
+						"components": [
+							{
+								"type": "library",
+								"name": "leftpad",
+								"version": "0.0.1",
+								"description": "left pad numbers",
+								"licenses": [
+									{
+										"license": {
+											"id": "BSD-3-Clause"
+										}
+									}
+								],
+								"purl": "pkg:npm/leftpad@0.0.1"
+							}
+						]
+					}`), 0600)).To(Succeed())
 					return nil
 				}
 
@@ -379,43 +365,38 @@ func testModuleBOM(t *testing.T, context spec.G, it spec.S) {
 			context("cannot decode base64 encoded checksum", func() {
 				it.Before(func() {
 					executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
-						Expect(os.WriteFile(filepath.Join(workingDir, "bom.json"), []byte(
-							`
-{
-  "components": [
-    {
-      "type": "library",
-      "name": "leftpad",
-      "version": "0.0.1",
-      "description": "left pad numbers",
-      "licenses": [
-        {
-          "license": {
-            "id": "BSD-3-Clause"
-          }
-        }
-      ],
-      "purl": "pkg:npm/leftpad@0.0.1"
-		}
-  ]
-}
-`), 0600)).To(Succeed())
+						Expect(os.WriteFile(filepath.Join(workingDir, "bom.json"), []byte(`{
+							"components": [
+								{
+									"type": "library",
+									"name": "leftpad",
+									"version": "0.0.1",
+									"description": "left pad numbers",
+									"licenses": [
+										{
+											"license": {
+												"id": "BSD-3-Clause"
+											}
+										}
+									],
+									"purl": "pkg:npm/leftpad@0.0.1"
+								}
+							]
+						}`), 0600)).To(Succeed())
 						return nil
 					}
 
-					Expect(os.WriteFile(filepath.Join(workingDir, "package-lock.json"), []byte(`
-{
-  "name": "simple_app",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "leftpad": {
-      "version": "0.0.1",
-			"integrity": "sha512-???"
-    }
-  }
-}
-`), 0600)).To(Succeed())
+					Expect(os.WriteFile(filepath.Join(workingDir, "package-lock.json"), []byte(`{
+						"name": "simple_app",
+						"lockfileVersion": 1,
+						"requires": true,
+						"dependencies": {
+							"leftpad": {
+								"version": "0.0.1",
+								"integrity": "sha512-???"
+							}
+						}
+					}`), 0600)).To(Succeed())
 
 				})
 				it.After(func() {
@@ -444,25 +425,22 @@ func testModuleBOM(t *testing.T, context spec.G, it spec.S) {
 			context("the BOM entry contains unsupported checksum algorithm", func() {
 				it.Before(func() {
 					executable.ExecuteCall.Stub = func(execution pexec.Execution) error {
-						Expect(os.WriteFile(filepath.Join(workingDir, "bom.json"), []byte(
-							`
-{
-  "components": [
-    {
-      "type": "library",
-      "name": "leftpad",
-      "version": "0.0.1",
-      "description": "left pad numbers",
-      "hashes": [
-        {
-          "alg": "randomAlgorithm",
-          "content": "86b1a4de4face180ac545a83f1503523d8fed115"
-        }
-      ]
-		}
-  ]
-}
-`), 0600)).To(Succeed())
+						Expect(os.WriteFile(filepath.Join(workingDir, "bom.json"), []byte(`{
+							"components": [
+								{
+									"type": "library",
+									"name": "leftpad",
+									"version": "0.0.1",
+									"description": "left pad numbers",
+									"hashes": [
+										{
+											"alg": "randomAlgorithm",
+											"content": "86b1a4de4face180ac545a83f1503523d8fed115"
+										}
+									]
+								}
+							]
+						}`), 0600)).To(Succeed())
 						return nil
 					}
 

--- a/package_lock.go
+++ b/package_lock.go
@@ -1,0 +1,66 @@
+package nodemodulebom
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/paketo-buildpacks/packit"
+)
+
+type PackageLock struct {
+	Name            string                 `json:"name"`
+	LockfileVersion int                    `json:"lockfileVersion"`
+	Dependencies    map[string]interface{} `json:"dependencies"`
+}
+
+func NewPackageLock(workingDir string) (PackageLock, error) {
+	file, err := os.Open(filepath.Join(workingDir, "package-lock.json"))
+	if err != nil {
+		return PackageLock{}, fmt.Errorf("failed to open package-lock.json: %w", err)
+	}
+	defer file.Close()
+
+	var lockFileContent PackageLock
+	err = json.NewDecoder(file).Decode(&lockFileContent)
+	if err != nil {
+		return PackageLock{}, fmt.Errorf("failed to decode package-lock: %w", err)
+	}
+	return lockFileContent, nil
+}
+
+// FindChecksum is a function that will read the package-lock.json if there is
+// one, and retrieve the integrity (hash) for a specific dependency. It returns
+// packit.BOMChecksum containing the algorithm and hash.
+func (p PackageLock) FindChecksum(pkg string) (packit.BOMChecksum, error) {
+	for name, dependency := range p.Dependencies {
+		if name == pkg {
+			dependencyMap := dependency.(map[string]interface{})
+			integrity := dependencyMap["integrity"].(string)
+
+			if strings.Contains(integrity, "-") {
+				algAndHash := strings.Split(integrity, "-")
+				hash, err := base64.StdEncoding.DecodeString(algAndHash[1])
+				if err != nil {
+					return packit.BOMChecksum{}, err
+				}
+
+				algorithm, err := packit.GetBOMChecksumAlgorithm(algAndHash[0])
+				if err != nil {
+					return packit.BOMChecksum{}, err
+				}
+
+				return packit.BOMChecksum{
+					Algorithm: algorithm,
+					Hash:      hex.EncodeToString(hash),
+				}, nil
+			}
+			return packit.BOMChecksum{}, nil
+		}
+	}
+	return packit.BOMChecksum{}, nil
+}

--- a/package_lock_test.go
+++ b/package_lock_test.go
@@ -1,0 +1,160 @@
+package nodemodulebom_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	nodemodulebom "github.com/paketo-buildpacks/node-module-bom"
+	"github.com/paketo-buildpacks/packit"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+)
+
+func testPackageLock(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect = NewWithT(t).Expect
+
+		workingDir string
+		lockfile   nodemodulebom.PackageLock
+	)
+
+	it.Before(func() {
+		var err error
+		workingDir, err = ioutil.TempDir("", "working-dir")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(os.WriteFile(filepath.Join(workingDir, "package-lock.json"), []byte(`
+			{
+				"name": "simple_app",
+				"lockfileVersion": 1,
+				"requires": true,
+				"dependencies": {
+					"leftpad": {
+						"version": "0.0.1",
+						"integrity": "sha256-YWJjZGU="
+					}
+				}
+			}`), 0600)).To(Succeed())
+
+		lockfile, err = nodemodulebom.NewPackageLock(workingDir)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	it.After(func() {
+		Expect(os.RemoveAll(workingDir)).To(Succeed())
+	})
+
+	context("FindChecksum", func() {
+		it("successfully retrieves checksum and returns a packit.BOMChecksum", func() {
+			checksum, err := lockfile.FindChecksum("leftpad")
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(checksum).To(Equal(packit.BOMChecksum{
+				Algorithm: packit.SHA256,
+				Hash:      "6162636465",
+			}))
+
+			context("package-lock.json does not contain matching dependency", func() {
+				it("returns an empty BOMChecksum", func() {
+					checksum, err := lockfile.FindChecksum("another-dependency")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(checksum).To(Equal(packit.BOMChecksum{}))
+				})
+			})
+
+			context("package-lock.json integrity is not formatted with '-'", func() {
+				it.Before(func() {
+					var err error
+					Expect(os.WriteFile(filepath.Join(workingDir, "package-lock.json"), []byte(`
+						{
+							"name": "simple_app",
+							"lockfileVersion": 1,
+							"requires": true,
+							"dependencies": {
+								"leftpad": {
+									"version": "0.0.1",
+									"integrity": "algorithmHash"
+								}
+							}
+						}`), 0600)).To(Succeed())
+					lockfile, err = nodemodulebom.NewPackageLock(workingDir)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it.After(func() {
+					Expect(os.RemoveAll(workingDir)).To(Succeed())
+				})
+
+				it("returns an empty BOMChecksum", func() {
+					checksum, err := lockfile.FindChecksum("leftpad")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(checksum).To(Equal(packit.BOMChecksum{}))
+				})
+			})
+		})
+
+		context("failure cases", func() {
+			context("cannot decode hash string", func() {
+				it.Before(func() {
+					var err error
+					Expect(os.WriteFile(filepath.Join(workingDir, "package-lock.json"), []byte(`
+						{
+							"name": "simple_app",
+							"lockfileVersion": 1,
+							"requires": true,
+							"dependencies": {
+								"leftpad": {
+									"version": "0.0.1",
+									"integrity": "sha256-%%"
+								}
+							}
+						}`), 0600)).To(Succeed())
+					lockfile, err = nodemodulebom.NewPackageLock(workingDir)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it.After(func() {
+					Expect(os.RemoveAll(workingDir)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := lockfile.FindChecksum("leftpad")
+					Expect(err).To(MatchError(ContainSubstring("illegal base64 data at input byte 0")))
+				})
+			})
+
+			context("cannot get a packit.BOMChecksumAlgorithm from algorithm", func() {
+				it.Before(func() {
+					var err error
+					Expect(os.WriteFile(filepath.Join(workingDir, "package-lock.json"), []byte(`
+						{
+							"name": "simple_app",
+							"lockfileVersion": 1,
+							"requires": true,
+							"dependencies": {
+								"leftpad": {
+									"version": "0.0.1",
+									"integrity": "randomAlg-YWJjZGU="
+								}
+							}
+						}`), 0600)).To(Succeed())
+					lockfile, err = nodemodulebom.NewPackageLock(workingDir)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				it.After(func() {
+					Expect(os.RemoveAll(workingDir)).To(Succeed())
+				})
+
+				it("returns an error", func() {
+					_, err := lockfile.FindChecksum("leftpad")
+					Expect(err).To(MatchError(ContainSubstring("failed to get supported BOM checksum algorithm: randomAlg is not valid")))
+				})
+			})
+		})
+
+	})
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Workaround to resolve #6 

## Use Cases
<!-- An explanation of the use cases your change enables -->

Look up the integrity (checksum) for each node module in the `package-lock.json` if:
- the cyclonedx bom tool doesn't find one (this is a problem in Node Engine V14+ / NPM v7+ due to NPM 7's package.json changes)
- there is a `package-lock.json` file present

We do plan to contribute a change to the upstream BOM tool, so this workaround may be temporary.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
