### PR TITLE
Add integration test for the lockfile version 2 case

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -119,6 +119,7 @@ func TestIntegration(t *testing.T) {
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("NPM", testNPM)
 	suite("Offline", testOffline)
+	suite("PackageLockHashes", testPackageLockHashes)
 	suite("Vendored", testVendored)
 	suite("Yarn", testYarn)
 	suite.Run(t)

--- a/integration/package_lock_hashses_test.go
+++ b/integration/package_lock_hashses_test.go
@@ -1,0 +1,91 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/paketo-buildpacks/occam"
+	"github.com/sclevine/spec"
+
+	. "github.com/onsi/gomega"
+	. "github.com/paketo-buildpacks/occam/matchers"
+)
+
+func testPackageLockHashes(t *testing.T, context spec.G, it spec.S) {
+	var (
+		Expect     = NewWithT(t).Expect
+		Eventually = NewWithT(t).Eventually
+
+		pack   occam.Pack
+		docker occam.Docker
+	)
+
+	it.Before(func() {
+		pack = occam.NewPack()
+		docker = occam.NewDocker()
+	})
+
+	context("when the buildpack is run with pack build", func() {
+		var (
+			image     occam.Image
+			container occam.Container
+			name      string
+			source    string
+		)
+
+		it.Before(func() {
+			var err error
+			name, err = occam.RandomName()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		it.After(func() {
+			Expect(docker.Image.Remove.Execute(image.ID)).To(Succeed())
+			Expect(docker.Volume.Remove.Execute(occam.CacheVolumeNames(name))).To(Succeed())
+			Expect(os.RemoveAll(source)).To(Succeed())
+		})
+
+		// BP_NODE_VERSION is set to ~16, which is a version of node-engine that
+		// uses NPM 7.  NPM 7 makes use of lockfile version 2, which has changes to
+		// the metadata contained within the `package-lock.json` file as well as
+		// the node modules `package.json` files.  Check out
+		// https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json#lockfileversion
+		// for more information about the lockfile.
+		context("building an NPM app that uses a NPM version with package-lock.json lockfile version 2", func() {
+			it.After(func() {
+				Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+			})
+
+			it("builds, logs and runs correctly", func() {
+				var err error
+
+				source, err = occam.Source(filepath.Join("testdata", "npm_app"))
+				Expect(err).ToNot(HaveOccurred())
+
+				var logs fmt.Stringer
+				image, logs, err = pack.WithNoColor().Build.
+					WithPullPolicy("never").
+					WithBuildpacks(
+						nodeEngineBuildpack,
+						npmInstallBuildpack,
+						nodeModuleBOMBuildpack,
+						npmStartBuildpack,
+					).
+					WithEnv(map[string]string{"BP_NODE_VERSION": "~16"}).
+					Execute(name, source)
+				Expect(err).ToNot(HaveOccurred(), logs.String)
+
+				container, err = docker.Container.Run.
+					WithPublish("8080").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(container).Should(BeAvailable())
+				Eventually(container).Should(Serve(ContainSubstring("hello world")).OnPort(8080))
+				Expect(image.Labels["io.buildpacks.build.metadata"]).To(ContainSubstring(`"name":"leftpad","metadata":{"checksum":`))
+			})
+		})
+	})
+}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Adds a test case for the issue in #6. 

We originally opened #9 for this issue, which was a fix on the buildpack side, but we instead added a fix to the upstream cyclonedx-node-module tool, which was released in[ v3.0.6](https://github.com/CycloneDX/cyclonedx-node-module/releases/tag/v3.0.6). This new version of the tool is now used in the buildpack and causes the newly added test to pass.

## Use Cases
<!-- An explanation of the use cases your change enables -->

Tests the bom creation works as expected for apps that use package-lock.json lockfile version 2.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
