### PR TITLE
Disables SBOM generation

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -413,5 +413,26 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Expect(err).To(MatchError(ContainSubstring("failed to generate node module BOM")))
 			})
 		})
+
+		context("when BP_DISABLE_SBOM is set incorrectly", func() {
+			it.Before(func() {
+				os.Setenv("BP_DISABLE_SBOM", "not-a-bool")
+			})
+
+			it.After(func() {
+				os.Unsetenv("BP_DISABLE_SBOM")
+			})
+
+			it("returns an error", func() {
+				_, err := build(packit.BuildContext{
+					CNBPath:    cnbDir,
+					Platform:   packit.Platform{Path: "platform"},
+					Layers:     packit.Layers{Path: layersDir},
+					Stack:      "some-stack",
+					WorkingDir: workingDir,
+				})
+				Expect(err).To(MatchError(ContainSubstring("failed to parse BP_DISABLE_SBOM")))
+			})
+		})
 	})
 }

--- a/integration/npm_test.go
+++ b/integration/npm_test.go
@@ -29,10 +29,11 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 
 	context("when the buildpack is run with pack build", func() {
 		var (
-			image     occam.Image
-			container occam.Container
-			name      string
-			source    string
+			image      occam.Image
+			container1 occam.Container
+			container2 occam.Container
+			name       string
+			source     string
 		)
 
 		it.Before(func() {
@@ -49,7 +50,8 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 
 		context("building a basic npm app is pack built", func() {
 			it.After(func() {
-				Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+				Expect(docker.Container.Remove.Execute(container1.ID)).To(Succeed())
+				Expect(docker.Container.Remove.Execute(container2.ID)).To(Succeed())
 			})
 
 			it("builds, logs and runs correctly", func() {
@@ -70,14 +72,25 @@ func testNPM(t *testing.T, context spec.G, it spec.S) {
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
-				container, err = docker.Container.Run.
+				container1, err = docker.Container.Run.
 					WithPublish("8080").
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(container).Should(BeAvailable())
-				Eventually(container).Should(Serve(ContainSubstring("hello world")).OnPort(8080))
-				Expect(image.Labels["io.buildpacks.build.metadata"]).To(ContainSubstring(`"name":"leftpad"`))
+				Eventually(container1).Should(BeAvailable())
+				Eventually(container1).Should(Serve(ContainSubstring("hello world")).OnPort(8080))
+
+				container2, err = docker.Container.Run.
+					WithCommand("cat /layers/sbom/launch/sbom.legacy.json").
+					WithEntrypoint("launcher").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() string {
+					cLogs, err := docker.Container.Logs.Execute(container2.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return cLogs.String()
+				}).Should(ContainSubstring(`"name":"leftpad"`))
 			})
 		})
 	})

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -29,10 +29,11 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 
 	context("when the buildpack is run with pack build that is offline", func() {
 		var (
-			image     occam.Image
-			container occam.Container
-			name      string
-			source    string
+			image      occam.Image
+			container1 occam.Container
+			container2 occam.Container
+			name       string
+			source     string
 		)
 
 		it.Before(func() {
@@ -49,7 +50,8 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 
 		context("default vendored app builds offline", func() {
 			it.After(func() {
-				Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+				Expect(docker.Container.Remove.Execute(container1.ID)).To(Succeed())
+				Expect(docker.Container.Remove.Execute(container2.ID)).To(Succeed())
 			})
 
 			it("builds, logs and runs correctly", func() {
@@ -70,14 +72,25 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
-				container, err = docker.Container.Run.
+				container1, err = docker.Container.Run.
 					WithPublish("8080").
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(container).Should(BeAvailable())
-				Eventually(container).Should(Serve(ContainSubstring("hello world")).OnPort(8080))
-				Expect(image.Labels["io.buildpacks.build.metadata"]).To(ContainSubstring(`"name":"leftpad"`))
+				Eventually(container1).Should(BeAvailable())
+				Eventually(container1).Should(Serve(ContainSubstring("hello world")).OnPort(8080))
+
+				container2, err = docker.Container.Run.
+					WithCommand("cat /layers/sbom/launch/sbom.legacy.json").
+					WithEntrypoint("launcher").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() string {
+					cLogs, err := docker.Container.Logs.Execute(container2.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return cLogs.String()
+				}).Should(ContainSubstring(`"name":"leftpad"`))
 			})
 		})
 	})

--- a/integration/yarn_test.go
+++ b/integration/yarn_test.go
@@ -29,10 +29,11 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 
 	context("when the buildpack is run with pack build", func() {
 		var (
-			image     occam.Image
-			container occam.Container
-			name      string
-			source    string
+			image      occam.Image
+			container1 occam.Container
+			container2 occam.Container
+			name       string
+			source     string
 		)
 
 		it.Before(func() {
@@ -49,7 +50,8 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 
 		context("building a basic yarn app is pack built", func() {
 			it.After(func() {
-				Expect(docker.Container.Remove.Execute(container.ID)).To(Succeed())
+				Expect(docker.Container.Remove.Execute(container1.ID)).To(Succeed())
+				Expect(docker.Container.Remove.Execute(container2.ID)).To(Succeed())
 			})
 
 			it("builds, logs and runs correctly", func() {
@@ -71,14 +73,25 @@ func testYarn(t *testing.T, context spec.G, it spec.S) {
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
 
-				container, err = docker.Container.Run.
+				container1, err = docker.Container.Run.
 					WithPublish("8080").
 					Execute(image.ID)
 				Expect(err).NotTo(HaveOccurred())
 
-				Eventually(container).Should(BeAvailable())
-				Eventually(container).Should(Serve(ContainSubstring("hello world")).OnPort(8080))
-				Expect(image.Labels["io.buildpacks.build.metadata"]).To(ContainSubstring(`"name":"leftpad"`))
+				Eventually(container1).Should(BeAvailable())
+				Eventually(container1).Should(Serve(ContainSubstring("hello world")).OnPort(8080))
+
+				container2, err = docker.Container.Run.
+					WithCommand("cat /layers/sbom/launch/sbom.legacy.json").
+					WithEntrypoint("launcher").
+					Execute(image.ID)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() string {
+					cLogs, err := docker.Container.Logs.Execute(container2.ID)
+					Expect(err).NotTo(HaveOccurred())
+					return cLogs.String()
+				}).Should(ContainSubstring(`"name":"leftpad"`))
 			})
 		})
 	})

--- a/scripts/.util/tools.json
+++ b/scripts/.util/tools.json
@@ -1,5 +1,5 @@
 {
-  "createpackage": "v1.59.0",
+  "createpackage": "v1.60.1",
   "jam": "v1.2.0",
-  "pack": "v0.25.0"
+  "pack": "v0.26.0"
 }


### PR DESCRIPTION
This change will resolve #73 

I needed to update all the integration tests that were affected by upgrading pack to v0.26.0 by setting the entrypoint to launcher for each container run. I opened [another issue](https://github.com/paketo-buildpacks/node-module-bom/issues/82) to refactor the tests to make them more consistent with other buildpacks so that the entrypoint does not need to be set.